### PR TITLE
Release 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+Version 3.2.1 *(2021-10-01)*
+----------------------------
+- Update der About-Sektion in der App
+- Update des FHG-Feeds
+  - Behebt Absturz bei Feedmedien die ohne Größenangabe vom Server geliefert werden
+
 Version 3.2.0 *(2021-06-10)*
 ----------------------------
 - Vorläufige Anpassungen um WebUntis Vertretungsplan anzuzeigen

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     val kotlinVersion by extra("1.5.10")
-    val hiltVersion by extra("2.37")
+    val hiltVersion by extra("2.39")
 
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:4.2.2")
+        classpath("com.android.tools.build:gradle:7.0.2")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
         classpath("com.google.dagger:hilt-android-gradle-plugin:$hiltVersion")
         classpath("app.cash.licensee:licensee-gradle-plugin:1.1.0")

--- a/fhgapp/build.gradle.kts
+++ b/fhgapp/build.gradle.kts
@@ -36,8 +36,8 @@ android {
         applicationId = "xyz.jbapps.vplan"
         minSdk = 16
         targetSdk = 30
-        versionCode = 31
-        versionName = "3.2.0"
+        versionCode = 32
+        versionName = "3.2.1"
 
         vectorDrawables.useSupportLibrary = true
 

--- a/fhgapp/build.gradle.kts
+++ b/fhgapp/build.gradle.kts
@@ -112,23 +112,23 @@ dependencies {
 
     // Manually overwriting older annotations library versions because the older versions declare
     // their license with the wrong url.
-    implementation("org.jetbrains:annotations:21.0.1")
+    implementation("org.jetbrains:annotations:22.0.0")
 
     implementation("androidx.annotation:annotation:1.2.0")
-    implementation("androidx.core:core-ktx:1.5.0")
-    implementation("androidx.fragment:fragment-ktx:1.3.5")
-    implementation("com.google.android.material:material:1.3.0")
+    implementation("androidx.core:core-ktx:1.6.0")
+    implementation("androidx.fragment:fragment-ktx:1.3.6")
+    implementation("com.google.android.material:material:1.4.0")
     implementation("androidx.preference:preference-ktx:1.1.1")
     implementation("androidx.vectordrawable:vectordrawable:1.1.0")
-    implementation("androidx.constraintlayout:constraintlayout:2.0.4")
+    implementation("androidx.constraintlayout:constraintlayout:2.1.1")
     implementation("androidx.recyclerview:recyclerview:1.2.1")
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.3.1")
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
     implementation("androidx.lifecycle:lifecycle-common-java8:2.3.1")
-    implementation("androidx.paging:paging-runtime-ktx:3.0.0")
+    implementation("androidx.paging:paging-runtime-ktx:3.0.1")
 
-    implementation("com.jakewharton.timber:timber:4.7.1")
+    implementation("com.jakewharton.timber:timber:5.0.1")
 
     val okhttpVersion = "4.9.1"
     implementation("com.squareup.okhttp3:okhttp:$okhttpVersion")

--- a/fhgapp/build.gradle.kts
+++ b/fhgapp/build.gradle.kts
@@ -28,14 +28,14 @@ licensee {
 }
 
 android {
-    compileSdkVersion(30)
+    compileSdk = 30
 
     defaultConfig {
         // Legacy package name. Should probably be replaced with a domain I own. Cannot be changed
         // without losing user count, ratings and comments due to Google Play Store policies.
         applicationId = "xyz.jbapps.vplan"
-        minSdkVersion(16)
-        targetSdkVersion(30)
+        minSdk = 16
+        targetSdk = 30
         versionCode = 31
         versionName = "3.2.0"
 

--- a/fhgapp/proguard-rules.pro
+++ b/fhgapp/proguard-rules.pro
@@ -17,17 +17,25 @@
 # Debugging proguard:
 ###################################################################################################
 
--dontobfuscate
--dontshrink
+#-dontobfuscate
+#-dontshrink
 
 # Uncomment this to preserve the line number information for debugging stack traces.
--keepattributes SourceFile,LineNumberTable
+#-keepattributes SourceFile,LineNumberTable
 
 # If you keep the line number information, uncomment this to hide the original source file name.
--renamesourcefileattribute SourceFile
+#-renamesourcefileattribute SourceFile
 
 
 -dontwarn org.conscrypt.ConscryptHostnameVerifier
+-dontwarn org.bouncycastle.jsse.BCSSLParameters
+-dontwarn org.bouncycastle.jsse.BCSSLSocket
+-dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
+-dontwarn "org.conscrypt.Conscrypt$Version"
+-dontwarn org.conscrypt.Conscrypt
+-dontwarn org.openjsse.javax.net.ssl.SSLParameters
+-dontwarn org.openjsse.javax.net.ssl.SSLSocket
+-dontwarn org.openjsse.net.ssl.OpenJSSE
 
 -dontnote sun.misc.Unsafe
 -dontnote com.google.android.gms.common.**

--- a/fhgapp/src/main/java/de/jbamberger/fhgapp/repository/data/Feed.kt
+++ b/fhgapp/src/main/java/de/jbamberger/fhgapp/repository/data/Feed.kt
@@ -94,9 +94,9 @@ class FeedMedia(
 
     @JsonClass(generateAdapter = true)
     data class MediaDetails(
-        val width: Int,
-        val height: Int,
-        val file: String,
+        val width: Int?,
+        val height: Int?,
+        val file: String?,
         val sizes: Map<String, ImageSize>
     )
 

--- a/fhgapp/src/main/java/de/jbamberger/fhgapp/repository/util/Extensions.kt
+++ b/fhgapp/src/main/java/de/jbamberger/fhgapp/repository/util/Extensions.kt
@@ -18,37 +18,6 @@ package de.jbamberger.fhgapp.repository.util
 
 import android.os.Build
 import android.text.Html
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.Transformations
-import de.jbamberger.fhgapp.repository.data.FeedMedia
-
-/**
- * @author Jannik Bamberger (dev.jbamberger@gmail.com)
- */
-
-fun <X, Y> LiveData<X>.map(function: (X) -> Y): LiveData<Y> {
-    return Transformations.map(this, function)
-}
-
-fun <X, Y> LiveData<X>.switchMap(function: (X) -> LiveData<Y>): LiveData<Y> {
-    return Transformations.switchMap(this, function)
-}
-
-/**
- * returns width / height ratio or null, if not available
- *
- */
-fun FeedMedia.getSaveImgSize(): ImgSize {
-    val width = this.media_details.width
-    val height = this.media_details.height
-    return Pair(width, height)
-}
-
-typealias ImgSize = Pair<Int, Int>
-
-fun ImgSize.formatAsAspectRatio(fixedDirection: String = "H"): String {
-    return "$fixedDirection,${this.first}:${this.second}"
-}
 
 fun String.unescapeHtml(): String {
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {


### PR DESCRIPTION
- Fixes a crash induced by the feed parser when the server response contains media items without associated size metadata
- Bumps dependency and AGP version
- Prepare release 3.2.1 (32)